### PR TITLE
Add initial Makefile, fixes #1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/10 01:02:08 by yabukirento       #+#    #+#              #
-#    Updated: 2025/09/10 01:02:09 by yabukirento      ###   ########.fr        #
+#    Updated: 2025/09/12 18:38:44 by yabukirento      ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,8 +14,7 @@ NAME := webserv
 CXX := c++
 CXXFLAGS := -Wall -Wextra -Werror -std=c++98 -I.
 
-# 簡易: すべての .cpp を対象 (後で明示列挙/依存自動生成に改善)
-SRCS := $(shell find . -type f -name '*.cpp')
+SRCS := main.cpp
 OBJS := $(SRCS:.cpp=.o)
 
 all: $(NAME)
@@ -28,8 +27,10 @@ $(NAME): $(OBJS)
 
 clean:
 	rm -f $(OBJS)
+
 fclean: clean
 	rm -f $(NAME)
+
 re: fclean all
 
 .PHONY: all clean fclean re


### PR DESCRIPTION
This pull request makes a small change to the `Makefile` by explicitly specifying `main.cpp` as the source file instead of using all `.cpp` files found in the directory. This simplifies and clarifies which files are being compiled.

- Build configuration:
  * Changed the `SRCS` variable to include only `main.cpp` instead of all `.cpp` files found recursively.

- Minor formatting:
  * Added blank lines after the `clean` and `fclean` targets for improved readability.